### PR TITLE
docs: remove unused entry points and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Drop Radio is a live, endless, variable-quality multi-stream of the complete rec
 
 ## Would you like to help?
 
-Drop Radio is an [NX](https://nx.dev) monorepo hosted on [GitHub](https://github.com/resisttheurge/drop-radio). For proper maintainance, first clone the repository locally and then install its dependencies with `npm`:
+Drop Radio is an [NX](https://nx.dev) monorepo hosted on [GitHub](https://github.com/resisttheurge/drop-radio). For proper maintenance, first clone the repository locally and then install its dependencies with `npm`:
 
 ```shell
 git clone https://github.com/resisttheurge/drop-radio.git

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Drop Radio is a live, endless, variable-quality multi-stream of the complete rec
 
 ## Would you like to help?
 
-Drop Radio is an [NX](https://nx.dev) monorepo. For proper maintainance, first clone the repository locally and then install its dependencies with `npm`:
+Drop Radio is an [NX](https://nx.dev) monorepo hosted on [GitHub](https://github.com/resisttheurge/drop-radio). For proper maintainance, first clone the repository locally and then install its dependencies with `npm`:
 
 ```shell
 git clone https://github.com/resisttheurge/drop-radio.git

--- a/typedoc.config.mjs
+++ b/typedoc.config.mjs
@@ -11,7 +11,6 @@ const config = {
   out: 'generated-docs',
   packageOptions: {
     entryPoints: [
-      'README.md',
       'src/index.ts',
       'src/main.ts',
       'src/main.tsx'


### PR DESCRIPTION
Removed default 'README.md' from typedoc entry points because it was leftover from a workaround attempt that didn't pan out.

Updated README to link back to github from github-pages.