### PR TITLE
feature: enable ffmpeg input playlist and looping

### DIFF
--- a/libs/server/ffmpeg/src/lib/ffmpeg/HLSStreamOptions.ts
+++ b/libs/server/ffmpeg/src/lib/ffmpeg/HLSStreamOptions.ts
@@ -25,6 +25,19 @@ export interface HLSStreamFormat {
  */
 export interface HLSStreamOptions {
   /**
+   * An optional flag to indicate whether to expect the input to be a plain text
+   * file with a list of files to concatenate.
+   */
+  readonly concat?: boolean
+
+  /**
+   * An optional number of times to loop the input. If set to `-1`, the
+   * input will be looped indefinitely. If set to `0`, the input will be played
+   * once, and if set to `1`, it will be played twice, etc.
+   */
+  readonly loops?: number
+
+  /**
    * An optional list of formats to be used for the HLS stream. Each format
    * corresponds to an individual output stream with the specified name,
    * bitrate, and sample rate.
@@ -87,6 +100,8 @@ export interface HLSStreamOptions {
  */
 // #region HLS_STREAM_DEFAULTS
 export const HLS_STREAM_DEFAULTS: Required<HLSStreamOptions> = {
+  concat: false,
+  loops: 0,
   formats: [
     { name: '01_highest', bitrate: '1.528M', sampleRate: '96k' },
     { name: '02_high', bitrate: '640k', sampleRate: '48k' },

--- a/libs/server/ffmpeg/src/lib/ffmpeg/HLSStreamOptions.ts
+++ b/libs/server/ffmpeg/src/lib/ffmpeg/HLSStreamOptions.ts
@@ -35,7 +35,7 @@ export interface HLSStreamOptions {
    * input will be looped indefinitely. If set to `0`, the input will be played
    * once, and if set to `1`, it will be played twice, etc.
    */
-  readonly loops?: number
+  readonly loopCount?: number
 
   /**
    * An optional list of formats to be used for the HLS stream. Each format
@@ -101,7 +101,7 @@ export interface HLSStreamOptions {
 // #region HLS_STREAM_DEFAULTS
 export const HLS_STREAM_DEFAULTS: Required<HLSStreamOptions> = {
   concat: false,
-  loops: 0,
+  loopCount: 0,
   formats: [
     { name: '01_highest', bitrate: '1.528M', sampleRate: '96k' },
     { name: '02_high', bitrate: '640k', sampleRate: '48k' },

--- a/libs/server/ffmpeg/src/lib/ffmpeg/hlsStream.spec.ts
+++ b/libs/server/ffmpeg/src/lib/ffmpeg/hlsStream.spec.ts
@@ -177,7 +177,7 @@ describe('hlsStream', () => {
             '-re',
             ...args.seekTime,
             ...args.concat,
-            ...args.loop,
+            ...args.loopCount,
             ...['-i', inputFile],
             ...args.maps,
             ...args.sampleRates,
@@ -514,13 +514,14 @@ describe('toHLSStreamArgs', () => {
   it.prop([arbHLSStreamOptions()])(
     'produces the correct loop arguments',
     (options) => {
-      const expectedArgs: HLSStreamArgs['loop'] = [
+      const expectedArgs: HLSStreamArgs['loopCount'] = [
         '-stream_loop',
-        options.loops?.toString() ?? HLS_STREAM_DEFAULTS.loops.toString(),
+        options.loopCount?.toString() ??
+          HLS_STREAM_DEFAULTS.loopCount.toString(),
       ]
       const args = toHLSStreamArgs(options)
 
-      expect(args.loop).toEqual(expectedArgs)
+      expect(args.loopCount).toEqual(expectedArgs)
     }
   )
 
@@ -692,7 +693,7 @@ function arbHLSStreamFormat({
 
 function arbHLSStreamOptions({
   concat = fc.boolean(),
-  loops = fc.integer({ min: -1 }),
+  loopCount = fc.integer({ min: -1 }),
   formats = fc.array(arbHLSStreamFormat()),
   seekTime = fc.string(),
   segmentDuration = fc.integer({ min: 1 }),
@@ -704,7 +705,7 @@ function arbHLSStreamOptions({
   return fc.record(
     {
       concat,
-      loops,
+      loopCount,
       formats,
       seekTime,
       segmentDuration,

--- a/libs/server/ffmpeg/src/lib/ffmpeg/hlsStream.spec.ts
+++ b/libs/server/ffmpeg/src/lib/ffmpeg/hlsStream.spec.ts
@@ -176,6 +176,8 @@ describe('hlsStream', () => {
             ...['-progress', 'pipe:1'],
             '-re',
             ...args.seekTime,
+            ...args.concat,
+            ...args.loop,
             ...['-i', inputFile],
             ...args.maps,
             ...args.sampleRates,
@@ -498,6 +500,31 @@ describe('toHLSStreamArgs', () => {
   }
 
   it.prop([arbHLSStreamOptions()])(
+    'produces the correct concat arguments',
+    (options) => {
+      const expectedArgs: HLSStreamArgs['concat'] = options.concat
+        ? ['-f', 'concat', '-safe', '0']
+        : []
+      const args = toHLSStreamArgs(options)
+
+      expect(args.concat).toEqual(expectedArgs)
+    }
+  )
+
+  it.prop([arbHLSStreamOptions()])(
+    'produces the correct loop arguments',
+    (options) => {
+      const expectedArgs: HLSStreamArgs['loop'] = [
+        '-stream_loop',
+        options.loops?.toString() ?? HLS_STREAM_DEFAULTS.loops.toString(),
+      ]
+      const args = toHLSStreamArgs(options)
+
+      expect(args.loop).toEqual(expectedArgs)
+    }
+  )
+
+  it.prop([arbHLSStreamOptions()])(
     'produces the correct seek time arguments',
     (options) => {
       const expectedArgs: HLSStreamArgs['seekTime'] = [
@@ -664,6 +691,8 @@ function arbHLSStreamFormat({
 }
 
 function arbHLSStreamOptions({
+  concat = fc.boolean(),
+  loops = fc.integer({ min: -1 }),
   formats = fc.array(arbHLSStreamFormat()),
   seekTime = fc.string(),
   segmentDuration = fc.integer({ min: 1 }),
@@ -674,6 +703,8 @@ function arbHLSStreamOptions({
 }: ArbitraryConstraints<HLSStreamOptions> = {}): Arbitrary<HLSStreamOptions> {
   return fc.record(
     {
+      concat,
+      loops,
       formats,
       seekTime,
       segmentDuration,

--- a/libs/server/ffmpeg/src/lib/ffmpeg/hlsStream.ts
+++ b/libs/server/ffmpeg/src/lib/ffmpeg/hlsStream.ts
@@ -21,7 +21,7 @@ import { HLSStreamProgress, parseHLSStreamProgress } from './HLSStreamProgress'
  * to subscribe to the same observable multiple times at once, as `ffmpeg` will
  * gladly try to overwrite the same output files at the same time. In many cases,
  * use of the {@link HLSStreamOptions.concat} option is better suited for playlist
- * functionality, and {@link HLSStreamOptions.loops} for replay / looping.
+ * functionality, and {@link HLSStreamOptions.loopCount} for replay / looping.
  *
  * **Note**: `ffmpeg` HLS streaming will always leave behind the last playlist
  * and segment files it created when the process exits. If the same playlist

--- a/libs/server/ffmpeg/src/lib/ffmpeg/hlsStream.ts
+++ b/libs/server/ffmpeg/src/lib/ffmpeg/hlsStream.ts
@@ -35,9 +35,10 @@ import { HLSStreamProgress, parseHLSStreamProgress } from './HLSStreamProgress'
  *
  * @param {string} inputFile
  * The input file to stream. Expected to be a media file with at least one
- * audio stream, or, if `options.concat` is true, an [`ffconcat` playlist file]() for
- * playing
- * If this is a relative path, it will be resolved relative to the current working directory
+ * audio stream, or, if `options.concat` is true, an
+ * [`ffconcat` playlist file](https://ffmpeg.org/ffmpeg-formats.html#Syntax) to
+ * play back multiple files in succession. If this is a relative path, it will
+ * be resolved relative to the current working directory
  *
  * @param {string} workingDirectory
  * Optional directory to run `ffmpeg` in and output the resulting HLS files.
@@ -86,7 +87,7 @@ export function hlsStream(
         '-re', // read input in "real-time" to keep stream files "live"
         ...args.seekTime, // seek to the specified time before starting the stream
         ...args.concat, // concat input files if specified
-        ...args.loop, // loop the input file as specified
+        ...args.loopCount, // loop the input file as specified
         ...['-i', inputFile], // input file to stream
         ...args.maps, // map audio streams to output (multiplex for variable quality streams)
         ...args.sampleRates, // set sample rate for each output audio stream
@@ -209,7 +210,7 @@ export interface HLSStreamArgs {
    * If loops is `-1`, the input will loop indefinitely. If it's `0`, the input
    * will play once, and if it's `1`, it will play twice, etc.
    */
-  loop: ['-stream_loop', string]
+  loopCount: ['-stream_loop', string]
 
   /**
    * The time to seek to before starting the stream, in fractional seconds.
@@ -320,7 +321,7 @@ export interface HLSStreamArgs {
  */
 export function toHLSStreamArgs({
   concat = HLS_STREAM_DEFAULTS.concat,
-  loops = HLS_STREAM_DEFAULTS.loops,
+  loopCount = HLS_STREAM_DEFAULTS.loopCount,
   formats = HLS_STREAM_DEFAULTS.formats,
   seekTime = HLS_STREAM_DEFAULTS.seekTime,
   segmentDuration = HLS_STREAM_DEFAULTS.segmentDuration,
@@ -331,7 +332,7 @@ export function toHLSStreamArgs({
 }: HLSStreamOptions = {}): HLSStreamArgs {
   const result: HLSStreamArgs = {
     concat: concat ? ['-f', 'concat', '-safe', '0'] : [],
-    loop: ['-stream_loop', loops.toString()],
+    loopCount: ['-stream_loop', loopCount.toString()],
     seekTime: ['-ss', seekTime],
     maps: [],
     sampleRates: [],


### PR DESCRIPTION
Adds support for native ffmpeg playlist playback via the `-f concat`
option and playback looping via the `-stream_loop` option. Use of the
native ffmpeg functionality rather than using multple ffmpeg processes
with concatenated obeservables will result in smoother streams and cleaner
setup / teardown logic for the server.