### PR TITLE
hotfix: reduce stream overhead

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -50,7 +50,7 @@
         "executor": "@nx/js:node",
         "defaultConfiguration": "development",
         "dependsOn": [
-          "build"
+          "^build"
         ],
         "options": {
           "buildTarget": "@drop-radio/server:build",

--- a/libs/server/stream-plugin/src/lib/stream-plugin/index.ts
+++ b/libs/server/stream-plugin/src/lib/stream-plugin/index.ts
@@ -145,7 +145,12 @@ const streamPlugin: FastifyPluginAsync<StreamOptions> = async (
         concat: true,
         loopCount: -1,
         segmentDuration: 1,
-        segmentCount: 50,
+        segmentCount: 12,
+        formats: [
+          { name: 'high', bitrate: '640k', sampleRate: '48k' },
+          { name: 'low', bitrate: '32k', sampleRate: '12k' },
+        ],
+        masterPlaylistName: 'live',
       }
     )
       .pipe(

--- a/nx.json
+++ b/nx.json
@@ -87,14 +87,12 @@
     "@nx/esbuild:esbuild": {
       "cache": true,
       "dependsOn": ["^build"],
-      "inputs": ["production", "^production"],
-      "outputs": ["{projectRoot}/dist"]
+      "inputs": ["production", "^production"]
     },
     "@nx/js:swc": {
       "cache": true,
       "dependsOn": ["^build"],
-      "inputs": ["production", "^production"],
-      "outputs": ["{projectRoot}/dist"]
+      "inputs": ["production", "^production"]
     }
   }
 }


### PR DESCRIPTION
Primarily, this PR reduces the number of HLS stream variants from 5 to 2 in an attempt to reduce CPU overhead.