### PR TITLE
CICD Modernization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           filter: tree:0
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ^24.14.0
-          cache: 'npm'
 
       - name: Get installed Playwright version
         id: playwright-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: sergeysova/jq-action@v2
         id: playwright-version
         with:
-          cmd: jq .packages."node_modules/@playwright/test".version package-lock.json -r
+          cmd: 'jq .packages."node_modules/@playwright/test".version package-lock.json -r'
 
       - name: Cache playwright binaries
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: sergeysova/jq-action@v2
         id: playwright-version
         with:
-          cmd: 'jq .packages."node_modules/@playwright/test".version package-lock.json -r'
+          cmd: jq '.packages."node_modules/@playwright/test".version' package-lock.json -r
 
       - name: Cache playwright binaries
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   main:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,10 @@ jobs:
           node-version: ^24.14.0
 
       - name: Get installed Playwright version
+        uses: sergeysova/jq-action@v2
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
+        with:
+          cmd: jq .packages."node_modules/@playwright/test".version package-lock.json -r
 
       - name: Cache playwright binaries
         uses: actions/cache@v5
@@ -36,7 +38,7 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.value }}
 
       - run: npm ci --legacy-peer-deps
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
           fetch-depth: 0
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: ^24.14.0
           cache: 'npm'
 
       - name: Get installed Playwright version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - development
   workflow_dispatch:
 
 permissions:
@@ -15,7 +16,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        app: [server]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -31,52 +34,18 @@ jobs:
 
       - run: npm ci --legacy-peer-deps
 
-      - name: Build the server application
-        run: npx nx build server
+      - name: Build the ${{ matrix.app }} application
+        run: npx nx build ${{ matrix.app }}
 
-      - name: Generate docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
+      - name: Build and push Docker image
+        uses: ./.github/workflows/docker-build-push.yml
         with:
-          # list of Docker images to use as base name for tags
-          images: |
-            ghcr.io/resisttheurge/drop-radio-server
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            latest
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
+          image: drop-radio-${{ matrix.app }}
+          context: apps/${{ matrix.app }}
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
+      - name: Deploy to Cloud Run
+        uses: ./.github/workflows/gcp-run-deploy.yml
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push server image to GHCR
-        uses: docker/build-push-action@v6
-        with:
-          context: apps/server
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
-        with:
-          project_id: drop-radio
-          service_account: ${{ vars.GHA_CLOUD_RUN_SERVICE_ACCOUNT }}
-          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-
-      - name: Deploy new drop-radio-server revision to Cloud Run
-        uses: 'google-github-actions/deploy-cloudrun@v3'
-        with:
-          image: ${{ vars.ARTIFACT_REGISTRY_URL }}/resisttheurge/drop-radio-server:main
-          service: ${{ vars.SERVICE_NAME }}
+          image: drop-radio-${{ matrix.app }}
+          tag: ${{ github.event.base_ref }}
+          service: drop-radio-${{ matrix.app }}-${{ github.event.base_ref == 'main' && 'prod' || 'test' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           filter: tree:0
           fetch-depth: 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,29 +68,15 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Authenticate to Google Cloud Compute
-        id: auth-compute
-        uses: google-github-actions/auth@v2
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
         with:
           project_id: drop-radio
-          service_account: ${{ vars.compute_service_account }}
-          workload_identity_provider: ${{vars.workload_identity_provider}}
+          service_account: ${{ vars.GHA_CLOUD_RUN_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Set VM startup script
-        run: |
-          gcloud compute instances add-metadata ${{ vars.instance_name }} \
-            --zone=${{ vars.compute_zone }} \
-            --metadata=startup-script='#!/bin/bash
-              docker pull gcr.io/google.com/cloudsdktool/google-cloud-cli:slim
-              docker run --rm -v /var/drop-radio-server/input:/rsync-output gcr.io/google.com/cloudsdktool/google-cloud-cli:slim gcloud storage rsync -r gs://${{ vars.audio_bucket }} /rsync-output --delete-unmatched-destination-objects
-            '
-
-      - name: Update Google Compute Engine instance
-        run: |
-          gcloud compute instances update-container ${{ vars.instance_name }} \
-          --zone=${{ vars.compute_zone }} \
-          --container-image=ghcr.io/resisttheurge/drop-radio-server:latest \
-          --container-mount-host-path=mount-path=/app/input,host-path=/var/drop-radio-server/input,mode=ro
+      - name: Deploy new drop-radio-server revision to Cloud Run
+        uses: 'google-github-actions/deploy-cloudrun@v3'
+        with:
+          image: ${{ vars.ARTIFACT_REGISTRY_URL }}/resisttheurge/drop-radio-server:main
+          service: ${{ vars.SERVICE_NAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ^24.14.0
-          cache: 'npm'
 
       - run: npm ci --legacy-peer-deps
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,9 @@ jobs:
 
       # Cache node_modules
       - name: Setup Node.js and npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: ^24.14.0
           cache: 'npm'
 
       - run: npm ci --legacy-peer-deps

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,49 @@
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'The name of the Docker image to build and push'
+        required: true
+        type: string
+      context:
+        description: 'The path to the Docker build context'
+        required: true
+        type: string
+
+jobs:
+  docker-build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/resisttheurge/${{ inputs.image }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            latest
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Build and push server image to GHCR
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          context: ${{ inputs.context }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ^24.14.0
-          cache: 'npm'
 
       # Install dependencies
       - name:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           filter: tree:0
           fetch-depth: 0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,9 +19,9 @@ jobs:
 
       # Cache node_modules
       - name: Setup Node.js and npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: ^24.14.0
           cache: 'npm'
 
       # Install dependencies

--- a/.github/workflows/gcp-run-deploy.yml
+++ b/.github/workflows/gcp-run-deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy Docker Image to Cloud Run
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: |
+          The name of the Docker image to deploy to Cloud Run
+        required: true
+        type: string
+      service:
+        description: |
+          The name of the Cloud Run service to deploy
+        required: true
+        type: string
+
+jobs:
+  deploy-to-cloud-run:
+    name: Deploy ${{ inputs.image }} to ${{ inputs.service }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: drop-radio
+          service_account: ${{ vars.GHA_CLOUD_RUN_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Deploy ${{ inputs.service }} to Cloud Run
+        uses: 'google-github-actions/deploy-cloudrun@v3'
+        with:
+          service: ${{ inputs.service }}
+          image: ${{ vars.ARTIFACT_REGISTRY_URL }}/resisttheurge/${{ inputs.image }}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,22 @@
   "engines": {
     "node": ">=20.20.0"
   },
+  "devEngines": {
+    "runtime": [
+      {
+        "name": "node",
+        "version": "^24.14.0",
+        "onFail": "warn"
+      }
+    ],
+    "packageManager": [
+      {
+        "name": "npm",
+        "version": "^11.9.0",
+        "onFail": "warn"
+      }
+    ]
+  },
   "scripts": {
     "sync-audio": "gcloud storage rsync gs://drop-audio assets/drop-audio --recursive --delete-unmatched-destination-objects --exclude=.gitkeep",
     "docs": "typedoc --options typedoc.config.mjs"


### PR DESCRIPTION
- Update CICD actions to use the latest versions
- Use Podman instead of Docker
- Target Google Cloud Run instead of Cloud Compute for deployment